### PR TITLE
Do not hang on `colordiff --help` which breaks bash auto-completion

### DIFF
--- a/colordiff.pl
+++ b/colordiff.pl
@@ -98,6 +98,9 @@ sub check_for_file_arguments {
         if ($arg !~ /^-/) {
             $nonopts++;
         }
+        if ($arg eq "--help" || $arg eq "--version" || $arg eq "-v") {
+            $nonopts++;
+        }
     }
     return $nonopts;
 }

--- a/colordiff.pl
+++ b/colordiff.pl
@@ -22,7 +22,7 @@
 ########################################################################
 
 use strict;
-use Getopt::Long qw(:config pass_through);
+use Getopt::Long qw(:config pass_through no_auto_abbrev);
 use IPC::Open2;
 
 my $app_name     = 'colordiff';


### PR DESCRIPTION
Recognize that `--help`, `--version` and `-v` are options for `diff` and therefore do not act as a filter.

In addition, fix a bug that would eat `-v` and options like `-d` due to the auto_abbrev feature of Perls Getopt library.

This fixes a regression introduced with version 1.0.10.
