### PR TITLE
Missing option to control on/off ansi color code ...

### DIFF
--- a/README
+++ b/README
@@ -32,12 +32,12 @@ For example:
 $ colordiff file1 file2
 $ diff -u file1 file2 | colordiff
 
-You can pipe the output to 'less', using the '-R' option (some systems or
-terminal types may get better results using '-r' instead), which keeps the
-colour escape sequences, otherwise displayed incorrectly or discarded by
-'less':
+With option '--color=yes', you can pipe the colorful output to 'less', using the
+'-R' option (some systems or terminal types may get better results using '-r'
+instead), which keeps the colour escape sequences, otherwise displayed
+incorrectly or discarded by 'less':
 
-$ diff -u file1 file2 | colordiff | less -R
+$ diff -u file1 file2 | colordiff --color=yes | less -R
 
 If you have wdiff installed, colordiff will correctly colourise the added and
 removed text, provided that the '-n' option is given to wdiff:
@@ -66,7 +66,7 @@ function cvsdiff () { cvs diff $@ | colordiff; }
 
 Or, combining the idea above using 'less':
 
-function cvsdiff () { cvs diff $@ | colordiff |less -R; }
+function cvsdiff () { cvs diff $@ | colordiff --color=yes |less -R; }
 
 Note that the function name, cvsdiff, can be customized.
 

--- a/colordiff.pl
+++ b/colordiff.pl
@@ -161,12 +161,14 @@ sub detect_diff_type {
 my $enable_verifymode;
 my $specified_difftype;
 my $enable_fakeexitcode;
+my $colormode = "auto";
 GetOptions(
     # --enable-verifymode option is for testing behaviour of colordiff
     # against standard test diffs
     "verifymode" => \$enable_verifymode,
     "fakeexitcode" => \$enable_fakeexitcode,
-    "difftype=s" => \$specified_difftype
+    "difftype=s" => \$specified_difftype,
+    "color=s" => \$colormode
     # TODO - check that specified type is valid, issue warning if not
 );
 
@@ -255,9 +257,16 @@ foreach $config_file (@config_files) {
     }
 }
 
-# If output is to a file, switch off colours, unless 'color_patch' is set
+# --color=yes and --color=no will override the color_patches setting
+if ($colormode eq "yes") {
+    $color_patch = 1;
+} elsif ($colormode eq "no") {
+    $color_patch = 0;
+}
+
+# If output is not a terminal, switch off colours, unless 'color_patch' is set
 # Relates to http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=378563
-if ((-f STDOUT) && ($color_patch == 0)) {
+if ((! -t 1) && ($color_patch == 0)) {
     $plain_text  = '';
     $file_old    = '';
     $file_new    = '';

--- a/colordiffrc
+++ b/colordiffrc
@@ -4,9 +4,10 @@
 # colordiff output
 banner=no
 # By default, when colordiff output is being redirected
-# to a file, it detects this and does not colour-highlight
-# To make the patch file *include* colours, change the option
-# below to 'yes'
+# to a file or being piped out to other program, it detects
+# this and does not colour-highlight. To make the patch file
+# *include* colours, change the option below to 'yes'.  You
+# can also use the --color=yes|no option to overide this
 color_patches=no
 # Sometimes it can be useful to specify which diff command to
 # use: that can be specified here


### PR DESCRIPTION
Hi,

I have a use case like this:

Use colordiff to view the diff

```
svn diff | colordiff
```

Apply the patch to another dir (arrow up and edit last command in my shell)

```
svn diff | colordiff | patch -p0 -d another-working-copy
```

Unfortunately this does not work since ansi color chars are piped out to `patch`.  I have to save the diff first:

```
svn diff | colordiff > my.patch
patch -p0 -d another-working-copy < my.patch
```

This is somehow inconvenient, so my fix is to provide a new option `--color=yes|no|auto` similar to grep(1).

Also updated colordiffrc and README.

Thanks,<br>
Matt
