### PR TITLE
fix issue #4 without changing existing behaviour, just introduce new opti...

### DIFF
--- a/README
+++ b/README
@@ -39,6 +39,12 @@ colour escape sequences, otherwise displayed incorrectly or discarded by
 
 $ diff -u file1 file2 | colordiff | less -R
 
+Note above example assumes you set 'color_patches=yes' in your colordiffrc file
+if it exists, if you want to force disable colour escape sequences (for example
+pipe the output to patch(1)), you can use option '--color=no' to do that.
+
+$ diff -u file1 file2 | colordiff --color=no | patch -p0 -d another-working-dir
+
 If you have wdiff installed, colordiff will correctly colourise the added and
 removed text, provided that the '-n' option is given to wdiff:
 

--- a/colordiff.pl
+++ b/colordiff.pl
@@ -161,12 +161,14 @@ sub detect_diff_type {
 my $enable_verifymode;
 my $specified_difftype;
 my $enable_fakeexitcode;
+my $colormode = "auto";
 GetOptions(
     # --enable-verifymode option is for testing behaviour of colordiff
     # against standard test diffs
     "verifymode" => \$enable_verifymode,
     "fakeexitcode" => \$enable_fakeexitcode,
-    "difftype=s" => \$specified_difftype
+    "difftype=s" => \$specified_difftype,
+    "color=s" => \$colormode
     # TODO - check that specified type is valid, issue warning if not
 );
 
@@ -255,9 +257,17 @@ foreach $config_file (@config_files) {
     }
 }
 
-# If output is to a file, switch off colours, unless 'color_patch' is set
+# --color=yes and --color=no will override the color_patches setting
+if ($colormode eq "yes") {
+    $color_patch = 1;
+} elsif ($colormode eq "no") {
+    $color_patch = 0;
+}
+
+# If output is to a file, switch off colours, unless 'color_patch' is set, if
+# --color=no is specified, force disable colours too
 # Relates to http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=378563
-if ((-f STDOUT) && ($color_patch == 0)) {
+if (((-f STDOUT) && ($color_patch == 0)) || ($colormode eq "no")) {
     $plain_text  = '';
     $file_old    = '';
     $file_new    = '';


### PR DESCRIPTION
Thanks for being looking into my request deeply.

How about just introduce a new option '--color=yes|no|auto' to override $color_patch variable (color_patches setting), and don't change the original "-f STDOUT" condition but force colors on/off according to the value of $colormode.  The key change would be

```
-if ((-f STDOUT) && ($color_patch == 0)) {
+if (((-f STDOUT) && ($color_patch == 0)) || ($colormode eq "no")) {
```

I am sending a new pull request based on the start point where I forked: a79dc09.

```
~/ws/colordiff $ git log --pretty='%h %s (%an)' -2
a0e7e9c fix issue 4 without changing existing behaviour, just introduce new option --color=yes|no|auto (Matthew Wang)
a79dc09 Add '--fakeexitcode' option. (Dave Ewart)
```

I tested with following use cases:
### With color_patches=yes
- Expects color
  - git diff a79dc0 | ./colordiff.pl
  - git diff a79dc0 | ./colordiff.pl --color=yes
  - git diff a79dc0 | ./colordiff.pl --color=auto
  - git diff a79dc0 | ./colordiff.pl | less -r  
  - git diff a79dc0 | ./colordiff.pl --color=yes | less -r
  - git diff a79dc0 | ./colordiff.pl --color=auto | less -r
  - git diff a79dc0 | ./colordiff.pl > out
  - git diff a79dc0 | ./colordiff.pl --color=yes > out
  - git diff a79dc0 | ./colordiff.pl --color=auto > out
- Expects no color
  - git diff a79dc0 | ./colordiff.pl --color=no
  - git diff a79dc0 | ./colordiff.pl --color=no | less -r
  - git diff a79dc0 | ./colordiff.pl --color=no > out
### With color_patches=no
- Expects color
  - git diff a79dc0 | ./colordiff.pl
  - git diff a79dc0 | ./colordiff.pl --color=yes
  - git diff a79dc0 | ./colordiff.pl --color=auto
  - git diff a79dc0 | ./colordiff.pl | less -r  
  - git diff a79dc0 | ./colordiff.pl --color=yes | less -r
  - git diff a79dc0 | ./colordiff.pl --color=auto | less -r
  - git diff a79dc0 | ./colordiff.pl --color=yes > out
- Expects no color
  - git diff a79dc0 | ./colordiff.pl > out
  - git diff a79dc0 | ./colordiff.pl --color=auto > out
  - git diff a79dc0 | ./colordiff.pl --color=no
  - git diff a79dc0 | ./colordiff.pl --color=no | less -r
  - git diff a79dc0 | ./colordiff.pl --color=no > out
