### PR TITLE
Fixed path to perl

### DIFF
--- a/colordiff.pl
+++ b/colordiff.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 
 ########################################################################
 #                                                                      #
@@ -22,6 +22,7 @@
 ########################################################################
 
 use strict;
+use warnings;
 use Getopt::Long qw(:config pass_through no_auto_abbrev);
 use IPC::Open2;
 


### PR DESCRIPTION
It doesn't work without patch. For example:

zsh: /usr/local/bin/colordiff: bad interpreter: /usr/bin/perl: no such file or directory
