### PR TITLE
Disable output buffering

### DIFF
--- a/colordiff.pl
+++ b/colordiff.pl
@@ -277,6 +277,10 @@ if ((-f STDOUT) && ($color_patch == 0)) {
     $colour{off} = '';
 }
 
+# Disable output buffering. This allows "producer | colordiff | less" to output
+# earlier without having to wait for 'producer' to finish.
+select STDOUT;
+$| = 1;
 
 # ----------------------------------------------------------------------------
 


### PR DESCRIPTION
The performance benefit of buffering is minimal, the blocking behavior on piping
to a secondary program is annoying.

Test set-up:
- "diff" is a file produced from `git diff` in the ACPICA repository and
  consists of 965214 lines.
- Command: time `colordiff < diff > /dev/null`

Before this patch:

```
real    0m2.602s
user    0m2.584s
sys     0m0.016s
```

After this patch:

```
real    0m3.470s
user    0m3.048s
sys     0m0.416s
```

As you can see, there is a difference, but given that there are likely other
limitating factors (tty speed, input buffering, disk speed), this increased time
can be ignored. With small diffs, there is even no noticable difference.
