### PR TITLE
Added support for prefixed installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
-INSTALL_DIR=/usr/local/bin
-MAN_DIR=/usr/local/man/man1
-ETC_DIR=/etc
+PREFIX ?= /
+INSTALL_DIR=$(PREFIX)/usr/local/bin
+MAN_DIR=$(PREFIX)/usr/local/man/man1
+ETC_DIR=$(PREFIX)/etc
 VERSION=$(shell egrep '^my .version' colordiff.pl |cut -f 2 -d "'")
 DIST_FILES=COPYING INSTALL Makefile README \
 	colordiff.pl colordiffrc colordiffrc-lightbg cdiff.sh BUGS CHANGES colordiff.1 \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-PREFIX ?= /
-INSTALL_DIR=$(PREFIX)/usr/local/bin
-MAN_DIR=$(PREFIX)/usr/local/man/man1
-ETC_DIR=$(PREFIX)/etc
+prefix=/usr/local
+INSTALL_DIR=$(prefix)/bin
+MAN_DIR=$(prefix)/man/man1
+ETC_DIR=$(prefix)/etc
 VERSION=$(shell egrep '^my .version' colordiff.pl |cut -f 2 -d "'")
 DIST_FILES=COPYING INSTALL Makefile README \
 	colordiff.pl colordiffrc colordiffrc-lightbg cdiff.sh BUGS CHANGES colordiff.1 \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 prefix=/usr/local
 INSTALL_DIR=$(prefix)/bin
-MAN_DIR=$(prefix)/man/man1
+MAN_DIR=$(prefix)/share/man/man1
 ETC_DIR=$(prefix)/etc
 VERSION=$(shell egrep '^my .version' colordiff.pl |cut -f 2 -d "'")
 DIST_FILES=COPYING INSTALL Makefile README \


### PR DESCRIPTION
Motivation: makes rootless installs possible without Makefile editing.
Example: mkdir -p  ${HOME}/local && make PREFIX=${HOME}/local install
