### PR TITLE
Fix high intensity color codes.

### DIFF
--- a/colordiff.pl
+++ b/colordiff.pl
@@ -218,7 +218,7 @@ foreach $config_file (@config_files) {
                     $colourval = "\033[0;3${value}m";
                 }
                 elsif( $value < 15 ) {
-                    $colourval = "\033[0;9${value}m";
+                    $colourval = "\033[0;9" . (${value} - 8) . "m";
                 }
                 else {
                     $colourval = "\033[0;38;5;${value}m";


### PR DESCRIPTION
The acceptable range for high-intensity color codes is 90-97.  There
for, we must subtract 8 from the number to bias the value correctly in
the range.
