### PR TITLE
Add new option '--noplusminus'

### DIFF
--- a/README
+++ b/README
@@ -75,6 +75,10 @@ function cvsdiff () { cvs diff $@ | colordiff |less -R; }
 
 Note that the function name, cvsdiff, can be customized.
 
+When option '--noplusminus' is used with unified diffs, the added space,
+plus or minus character will be removed from the diff output. Use this for
+your convenience when you would like to copy-paste multiple lines.
+
 By default colordiff returns the exit code of the underlying diff invocation
 (if there is one), but there are some circumstances where it is useful to force
 colordiff's exit code to be zero: to do this use the option '--fakeexitcode':

--- a/colordiff.pl
+++ b/colordiff.pl
@@ -158,12 +158,14 @@ sub detect_diff_type {
 my $enable_verifymode;
 my $specified_difftype;
 my $enable_fakeexitcode;
+my $disable_plusminus;
 my $color_mode = "auto";
 GetOptions(
     # --enable-verifymode option is for testing behaviour of colordiff
     # against standard test diffs
     "verifymode" => \$enable_verifymode,
     "fakeexitcode" => \$enable_fakeexitcode,
+    "noplusminus" => \$disable_plusminus,
     "difftype=s" => \$specified_difftype,
     "color=s" => \$color_mode
     # TODO - check that specified type is valid, issue warning if not
@@ -490,12 +492,15 @@ while (defined( $_ = @inputstream ? shift @inputstream : ($lastline and <$inputh
     elsif ($diff_type eq 'diffu') {
         if (/^-/) {
             print "$file_old";
+            $_ =~ s/^.// if (defined $disable_plusminus);
         }
         elsif (/^\+/) {
             print "$file_new";
+            $_ =~ s/^.// if (defined $disable_plusminus);
         }
         elsif (/^\@/) {
             print "$diff_stuff";
+            $_ =~ s/^.// if (defined $disable_plusminus);
         }
         elsif (/^Only in/) {
             print "$diff_stuff";
@@ -505,6 +510,7 @@ while (defined( $_ = @inputstream ? shift @inputstream : ($lastline and <$inputh
         }
         else {
             print "$plain_text";
+            $_ =~ s/^.// if (defined $disable_plusminus);
         }
     }
     # Works with previously-identified column containing the diff-y

--- a/colordiff.xml
+++ b/colordiff.xml
@@ -155,6 +155,12 @@ function cvsdiff () { cvs diff $@ | colordiff |less -R; }
 
 <para>Note that the function name, cvsdiff, can be customized.</para>
 
+<para>When option '--noplusminus' is used with unified diffs, the added space,
+plus or minus character will be removed from the diff output. Use this for
+your convenience when you would like to copy-paste multiple lines.
+
+</para>
+
 <para>By default colordiff returns the exit code of the underlying diff
 invocation (if there is one), but there are some circumstances where it is
 useful to force colordiff's exit code to be zero: to do this use the option


### PR DESCRIPTION
This option removes first character of unified diff output. This makes
it more convenient to copy-paste multiple lines from colordiff output.

I use colordiff to compare router configurations and this option makes it very convenient to select added lines with mouse and copy them directly to the router cli. Only drawback is that the changed lines can't be find by first character of line any more.
