### PR TITLE
Fix empty output when --difftype is given; warn for invalid --difftype

### DIFF
--- a/colordiff.pl
+++ b/colordiff.pl
@@ -166,8 +166,12 @@ GetOptions(
     "fakeexitcode" => \$enable_fakeexitcode,
     "difftype=s" => \$specified_difftype,
     "color=s" => \$color_mode
-    # TODO - check that specified type is valid, issue warning if not
 );
+
+$_ = $specified_difftype;
+if (defined $_ and not /^diff[cuy]?|(deb|w)diff$/) {
+    print STDERR "Invalid --difftype value\n";
+}
 
 if (defined $enable_verifymode) {
     # When in verify mode, to ensure consistent output we don't source

--- a/colordiff.pl
+++ b/colordiff.pl
@@ -308,16 +308,21 @@ if ($operating_methodology == 1) {
 # Input stream has been read - need to examine it
 # to determine type of diff we have.
 
-my $lastline;
+# $lastline is false if the input is EOF. If true, then either more data is
+# available, or the last read succeeded (and the next read may return EOF).
+# Initially assume that the input is not EOF (for obvious reasons).
+my $lastline = 1;
 my $record;
 
 if (defined $specified_difftype) {
     $diff_type = $specified_difftype;
     # diffy needs at least one line to look at
-    if ($diff_type eq 'diffy' and ($_ = <$inputhandle>)) {
-        push @inputstream, $_;
+    if ($diff_type eq 'diffy') {
+        if (defined($_ = <$inputhandle>)) {
+            push @inputstream, $_;
+        }
+        $lastline = $_;
     }
-    $lastline = $_;
 }
 else {
     # Detect diff type, diffy is permitted


### PR DESCRIPTION
Patch 1:
After

```
commit 384eea619ec366f610d6c8070da724a7de69f1df
Author: Peter Wu <lekensteyn@gmail.com>
Date:   Sat Feb 23 00:55:27 2013 +0100

    Avoid reading input again if it was closed
```

the input would not be consumed anymore whenever --difftype was
specified for values other than 'diffy'. This happened because $lastline
is not initialized and the script thinks that it is EOF (and therefore
stops reading more data).

Fixes https://github.com/daveewart/colordiff/issues/22

---

Patch 2 adds validation of `--difftype` and prints a warning to stderr for invalid values.
