### PR TITLE
Add $XDG_CONFIG_HOME/colordiff/colordiffrc to list of config files

### DIFF
--- a/colordiff.pl
+++ b/colordiff.pl
@@ -66,6 +66,12 @@ my $HOME   = $ENV{HOME};
 my $etcdir = '/etc';
 my ($setting, $value);
 my @config_files = ("$etcdir/colordiffrc");
+if ($ENV{XDG_CONFIG_HOME} ne '') {
+    push (@config_files, "$ENV{XDG_CONFIG_HOME}/colordiff/colordiffrc")
+}
+elsif (defined $ENV{HOME}) {
+    push (@config_files, "$ENV{HOME}/.config/colordiff/colordiffrc")
+}
 push (@config_files, "$ENV{HOME}/.colordiffrc") if (defined $ENV{HOME});
 my $config_file;
 my $diff_type = 'unknown';


### PR DESCRIPTION
This PR adds a new config file to the list of config files checked, following the [XDG Base Directory Specification](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html).

The new config file is either `$XDG_CONFIG_HOME/colordiff/colordiffrc`, or `$HOME/.config/colordiff/colordiffrc` if `$XDG_CONFIG_HOME` is not present or empty.

This new config file is checked after `/etc/colordiffrc` and before `~/.colordiffrc`.

The advantages of following XDG Base Directory Specification are that
- It declutters user home directory;
- It allows easier versioning of config files (`.config` can be easily version-controlled).
