### PR TITLE
Fix "colordiff.pl 0 1"

### DIFF
--- a/colordiff.pl
+++ b/colordiff.pl
@@ -92,7 +92,7 @@ sub check_for_file_arguments {
     my $nonopts = 0;
     my $ddash = 0;
 
-    while (my $arg = shift) {
+    while (defined(my $arg = shift)) {
         if ($arg eq "--") {
             $ddash = 1;
             next;


### PR DESCRIPTION
The filename "0" must not be recognized as end of args
which was the case previously since "0" becomes "false" in perl
