### PR TITLE
Allow Makefile Variables to be overwritten

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-INSTALL_DIR=/usr/local/bin
-MAN_DIR=/usr/local/man/man1
-ETC_DIR=/etc
+INSTALL_DIR?=/usr/local/bin
+MAN_DIR?=/usr/local/man/man1
+ETC_DIR?=/etc
 VERSION=$(shell egrep '^my .version' colordiff.pl |cut -f 2 -d "'")
 DIST_FILES=COPYING INSTALL Makefile README \
 	colordiff.pl colordiffrc colordiffrc-lightbg cdiff.sh BUGS CHANGES colordiff.1 \


### PR DESCRIPTION
This increases portability. This was used to build colordiff on Termux: https://github.com/termux/termux-packages/pull/548