### PR TITLE
Accept --color=always and --color=never options.

### DIFF
--- a/colordiff.pl
+++ b/colordiff.pl
@@ -281,10 +281,10 @@ foreach $config_file (@config_files) {
     }
 }
 
-# --color=(yes|no|auto) will override the color_patches setting
-if ($color_mode eq "yes") {
+# --color=(yes|no|always|never|auto) will override the color_patches setting
+if ($color_mode eq "yes" || $color_mode eq "always") {
     $color_patch = 1;
-} elsif ($color_mode eq "no") {
+} elsif ($color_mode eq "no" || $color_mode eq "never") {
     $color_patch = 0;
 } elsif ($color_mode eq "auto") {
     $color_patch = undef;


### PR DESCRIPTION
For the --color option, accept "always" as an alias for "yes" and
"never" as an alias for "no", because GNU diff uses "always" and "never"
instead of "yes" and "no".  This allows colordiff to operate as expected
if used as a drop-in replacement for a GNU diff command line already
containing "--color=always", which is better than forcing the user to
change the option to "--color=yes".