### PR TITLE
config: C:\ProgramData as /etc equiv. on Windows

### DIFF
--- a/colordiff.pl
+++ b/colordiff.pl
@@ -75,7 +75,8 @@ my $color_patch      = undef;
 # Locations for personal and system-wide colour configurations
 my $HOME = (grep { defined && length }
         @ENV{qw/HOME USERPROFILE/})[0] || '';
-my $etcdir = '/etc';
+my $etcdir = (grep { defined && length && -d }
+	'/etc', $ENV{ALLUSERSPROFILE})[0] || '/etc';
 my ($setting, $value);
 my @config_files = ("$etcdir/colordiffrc");
 my $USER_CONFIG_DIR = (grep { defined && length }


### PR DESCRIPTION
On Windows, C:\ProgramData, set in the ALLUSERSPROFILE environment
variable functions similarly to the /etc directory on UNIX in modern
Windows versions.

Check for the first existing directory in the list '/etc',
$ENV{ALLUSERSPROFILE}, in that order, and use it as $etcdir.

Followup on 6e4c670 (Support config file on Windows., 2022-02-08).

Signed-off-by: Rafael Kitover <rkitover@gmail.com>