### PR TITLE
Provide Unicode/UTF-8 Support for Wide Chars

### DIFF
--- a/colordiff.pl
+++ b/colordiff.pl
@@ -23,6 +23,7 @@
 
 use warnings;
 use strict;
+use open qw( :std :encoding(UTF-8) );
 use Getopt::Long qw(:config pass_through no_auto_abbrev);
 
 my $app_name     = 'colordiff';
@@ -92,16 +93,44 @@ my $config_file;
 my $diff_type = 'unknown';
 
 # Convert tabs to spaces
+if   ( eval "use Text::VisualWidth::PP; 1" )
+     { eval q{ sub _width  { return Text::VisualWidth::PP::width($_[0]) } } }
+else { eval q{ sub _width  { return my $offs = () = /\PM/g } } }
+
+our $tabstop = 8;
+
 sub expand_tabs_to_spaces ($) {
-    my ($s) = @_;
-    while ((my $i = index ($s, "\t")) > -1) {
-        substr (
-            $s, $i, 1,    # range to replace
-            (' ' x (8 - ($i % 8))),    # string to replace with
-            );
-    }
-    $s;
+        my @l;
+        my $pad;
+        for ( @_ ) {
+                defined or do { push @l, ''; next };
+                my $s = '';
+                for (split(/^/m, $_, -1)) {
+                        my $offs;
+                        for (split(/\t/, $_, -1)) {
+                                if (defined $offs) {
+                                        $pad = $tabstop - $offs % $tabstop;
+                                        $s .= " " x $pad;
+                                }
+                                $s .= $_;
+                                $offs = _width($_);
+                        }
+                }
+                push(@l, $s);
+        }
+        return @l if wantarray;
+        return $l[0];
 }
+
+sub _substr {
+    my ( $str, $offset, $length ) = @_;
+    my $s = '';
+
+    while ( do { my $width = _width($str); $offset && $width && $width >= $offset } ) { $str =~ s/^(\X)//; $offset -= _width($1) }
+    while ( do { my $width = _width($str); $length && $width && $width >= $length } ) { $str =~ s/^(\X)//; $length -= _width($1); $s .= $1 }
+    return $s;
+}
+
 
 sub check_for_file_arguments {
     my $nonopts = 0;
@@ -466,7 +495,7 @@ if ($diff_type eq 'diffy') {
         for (my $i = 0 ; $i < (length ($_) - 2) ; $i++) {
             next if ($separator_col{$i} == 0);
             next if ($_ =~ /^(Index: |={4,}|RCS file: |retrieving |diff )/);
-            my $subsub = substr ($_, $i, 2);
+            my $subsub = _substr ($_, $i, 2);
             if ($subsub !~ / [ (|<>]/) {
                 $separator_col{$i} = 0;
                 if ($candidate_col{$i} > 0) {

--- a/verify/unicode.diffy.diff
+++ b/verify/unicode.diffy.diff
@@ -1,0 +1,22 @@
+Agnes               en_US    # Isn't it nice to have a comput <
+Albert              en_US    # I have a frog in my throat. No	Albert              en_US    # I have a frog in my throat. No
+Alex                en_US    # Most people recognize me by my <
+Alice               it_IT    # Salve, mi chiamo Alice e sono 	Alice               it_IT    # Salve, mi chiamo Alice e sono 
+Allison             en_US    # Hello, my name is Allison. I a <
+Allison (Enhanced)  en_US    # Hello, my name is Allison. I a <
+Alva                sv_SE    # Hej, jag heter Alva. Jag är en	Alva                sv_SE    # Hej, jag heter Alva. Jag är en
+Amélie              fr_CA    # Bonjour, je m'appelle Amélie. 	Amélie              fr_CA    # Bonjour, je m'appelle Amélie. 
+Jacques             fr_FR    # Bonjour, je m’appelle Jacques.	Jacques             fr_FR    # Bonjour, je m’appelle Jacques.
+Joana               pt_PT    # Olá, chamo-me Joana e dou voz 	Joana               pt_PT    # Olá, chamo-me Joana e dou voz 
+Joelle (Enhanced)   en_US    # Hello, my name is Joelle. I am <
+Junior              en_US    # My favorite food is pizza.	Junior              en_US    # My favorite food is pizza.
+Kanya               th_TH    # สวัสดีค่ะ ดิฉันชื่อกันยา			Kanya               th_TH    # สวัสดีค่ะ ดิฉันชื่อกันยา
+Kyoko               ja_JP    # こんにちは、私の名前はきょうこ	Kyoko               ja_JP    # こんにちは、私の名前はきょうこ
+Lana                hr_HR    # Bog! Moje je ime Lana. Ja sam 	Lana                hr_HR    # Bog! Moje je ime Lana. Ja sam 
+Laura               sk_SK    # Ahoj. Volám sa Laura. Som hlas	Laura               sk_SK    # Ahoj. Volám sa Laura. Som hlas
+Lekha               hi_IN    # नमस्कार, मेरा नाम लेखा है! मैं हिन्दी	Lekha               hi_IN    # नमस्कार, मेरा नाम लेखा है! मैं हिन्दी
+Lesya               uk_UA    # Привіт, мене звуть Леся. Я — у	Lesya               uk_UA    # Привіт, мене звуть Леся. Я — у
+Linh                vi_VN    # Xin chào, tên tôi là Linh. Tôi	Linh                vi_VN    # Xin chào, tên tôi là Linh. Tôi
+Luciana             pt_BR    # Olá, o meu nome é Luciana e a 	Luciana             pt_BR    # Olá, o meu nome é Luciana e a 
+Majed               ar_001   # مرحبًا، اسمي ماجد. أنا صوتٌ عربي	Majed               ar_001   # مرحبًا، اسمي ماجد. أنا صوتٌ عربي
+Nathan              en_US    # Hello, my name is Nathan. I am <

--- a/verify/unicode.diffy.diff.output.reference
+++ b/verify/unicode.diffy.diff.output.reference
@@ -1,0 +1,22 @@
+[1;31mAgnes               en_US    # Isn't it nice to have a comput <[0;0m
+[1;37mAlbert              en_US    # I have a frog in my throat. No   Albert              en_US    # I have a frog in my throat. No[0;0m
+[1;31mAlex                en_US    # Most people recognize me by my <[0;0m
+[1;37mAlice               it_IT    # Salve, mi chiamo Alice e sono    Alice               it_IT    # Salve, mi chiamo Alice e sono [0;0m
+[1;31mAllison             en_US    # Hello, my name is Allison. I a <[0;0m
+[1;31mAllison (Enhanced)  en_US    # Hello, my name is Allison. I a <[0;0m
+[1;37mAlva                sv_SE    # Hej, jag heter Alva. Jag är en   Alva                sv_SE    # Hej, jag heter Alva. Jag är en[0;0m
+[1;37mAmélie              fr_CA    # Bonjour, je m'appelle Amélie.    Amélie              fr_CA    # Bonjour, je m'appelle Amélie. [0;0m
+[1;37mJacques             fr_FR    # Bonjour, je m’appelle Jacques.   Jacques             fr_FR    # Bonjour, je m’appelle Jacques.[0;0m
+[1;37mJoana               pt_PT    # Olá, chamo-me Joana e dou voz    Joana               pt_PT    # Olá, chamo-me Joana e dou voz [0;0m
+[1;31mJoelle (Enhanced)   en_US    # Hello, my name is Joelle. I am <[0;0m
+[1;37mJunior              en_US    # My favorite food is pizza.       Junior              en_US    # My favorite food is pizza.[0;0m
+[1;37mKanya               th_TH    # สวัสดีค่ะ ดิฉันชื่อกันยา                 Kanya               th_TH    # สวัสดีค่ะ ดิฉันชื่อกันยา[0;0m
+[1;37mKyoko               ja_JP    # こんにちは、私の名前はきょうこ   Kyoko               ja_JP    # こんにちは、私の名前はきょうこ[0;0m
+[1;37mLana                hr_HR    # Bog! Moje je ime Lana. Ja sam    Lana                hr_HR    # Bog! Moje je ime Lana. Ja sam [0;0m
+[1;37mLaura               sk_SK    # Ahoj. Volám sa Laura. Som hlas   Laura               sk_SK    # Ahoj. Volám sa Laura. Som hlas[0;0m
+[1;37mLekha               hi_IN    # नमस्कार, मेरा नाम लेखा है! मैं हिन्दी   Lekha               hi_IN    # नमस्कार, मेरा नाम लेखा है! मैं हिन्दी[0;0m
+[1;37mLesya               uk_UA    # Привіт, мене звуть Леся. Я — у   Lesya               uk_UA    # Привіт, мене звуть Леся. Я — у[0;0m
+[1;37mLinh                vi_VN    # Xin chào, tên tôi là Linh. Tôi   Linh                vi_VN    # Xin chào, tên tôi là Linh. Tôi[0;0m
+[1;37mLuciana             pt_BR    # Olá, o meu nome é Luciana e a    Luciana             pt_BR    # Olá, o meu nome é Luciana e a [0;0m
+[1;37mMajed               ar_001   # مرحبًا، اسمي ماجد. أنا صوتٌ عربي   Majed               ar_001   # مرحبًا، اسمي ماجد. أنا صوتٌ عربي[0;0m
+[1;31mNathan              en_US    # Hello, my name is Nathan. I am <[0;0m

--- a/verify/verify.output.MD5SUMS.reference
+++ b/verify/verify.output.MD5SUMS.reference
@@ -18,4 +18,5 @@ fd7122cc597bd2f3d29a875971b6df8b  plain.diffy.diff.output
 09867f65533fd9957d575745e54c383f  sdiff-l.diff.output
 13e5aa6b795202a0e30ca1aca08ec0fb  svn.diff.output
 8dc5ee05828b2aa0a3eed5503d141e28  svn.log.diff.output
+8ffeb59f9e114cac447f0bd86c917555  unicode.diffy.diff.output
 1d628b0a0f196787acf7ca1f930d1a46  wdiff1.diff.output


### PR DESCRIPTION
I noticed colordiff was getting confused by UTF-8 / Unicode — in particular, `diff -y` takes "wide" characters into account when aligning its `>|<` marker, but `colordiff` was miscalculating where to look for that column.

N.B.  I wasn't sure how you'd feel about 3rd-party dependencies like [`Text::VisualWidth::PP`](https://metacpan.org/pod/Text::VisualWidth::PP)...  You'll either think this is a reasonably clever fall-back — though it doesn't fix the problem in **all** cases — or you'll throw up in your mouth a little; I'm fine with either!  🙃

```
if   ( eval "use Text::VisualWidth::PP; 1" ) 
     { eval q{ sub _width  { return Text::VisualWidth::PP::width($_[0]) } } }
else { eval q{ sub _width  { return my $offs = () = /\PM/g } } }
```

Thanks!